### PR TITLE
Upgrade multus to the latest release (#238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ _kubevirtci/
 
 # testing
 _out
-
-# temp files
-cluster/multus-daemonset.yml

--- a/cluster/multus-daemonset.yml
+++ b/cluster/multus-daemonset.yml
@@ -91,55 +91,6 @@ metadata:
   name: multus
   namespace: kube-system
 ---
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: multus-cni-config
-  namespace: kube-system
-  labels:
-    tier: node
-    app: multus
-data:
-  # NOTE: If you'd prefer to manually apply a configuration file, you may create one here.
-  # In the case you'd like to customize the Multus installation, you should change the arguments to the Multus pod
-  # change the "args" line below from
-  # - "--multus-conf-file=auto"
-  # to:
-  # "--multus-conf-file=/tmp/multus-conf/70-multus.conf"
-  # Additionally -- you should ensure that the name "70-multus.conf" is the alphabetically first name in the
-  # /etc/cni/net.d/ directory on each node, otherwise, it will not be used by the Kubelet.
-  cni-conf.json: |
-    {
-      "name": "multus-cni-network",
-      "type": "multus",
-      "capabilities": {
-        "portMappings": true
-      },
-      "delegates": [
-        {
-          "cniVersion": "0.3.1",
-          "name": "default-cni-network",
-          "plugins": [
-            {
-              "type": "flannel",
-              "name": "flannel.1",
-                "delegate": {
-                  "isDefaultGateway": true,
-                  "hairpinMode": true
-                }
-              },
-              {
-                "type": "portmap",
-                "capabilities": {
-                  "portMappings": true
-                }
-              }
-          ]
-        }
-      ],
-      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
-    }
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -166,14 +117,19 @@ spec:
       tolerations:
         - operator: Exists
           effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
       serviceAccountName: multus
       containers:
         - name: kube-multus
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable
-          command: ["/entrypoint.sh"]
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
           args:
-            - "--multus-conf-file=auto"
-            - "--cni-version=0.3.1"
+            - "-cni-version=0.3.1"
+            - "-cni-config-dir=/host/etc/cni/net.d"
+            - "-multus-autoconfig-dir=/host/etc/cni/net.d"
+            - "-multus-log-to-stderr=true"
+            - "-multus-log-level=verbose"
           resources:
             requests:
               cpu: "100m"
@@ -188,8 +144,40 @@ spec:
               mountPath: /host/etc/cni/net.d
             - name: cnibin
               mountPath: /host/opt/cni/bin
-            - name: multus-cfg
-              mountPath: /tmp/multus-conf
+      initContainers:
+        - name: install-multus-binary
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          command:
+            - "cp"
+            - "/usr/src/multus-cni/bin/multus"
+            - "/host/opt/cni/bin/multus"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "15Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
+        - name: generate-kubeconfig
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          command:
+            - "/usr/src/multus-cni/bin/generate-kubeconfig"
+          args:
+            - "-k8s-service-host=$(KUBERNETES_SERVICE_HOST)"
+            - "-k8s-service-port=$(KUBERNETES_SERVICE_PORT)"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "15Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+              mountPropagation: Bidirectional
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
@@ -198,9 +186,3 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-        - name: multus-cfg
-          configMap:
-            name: multus-cni-config
-            items:
-              - key: cni-conf.json
-                path: 70-multus.conf

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -30,8 +30,5 @@ for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); d
 done
 
 echo 'Deploying multus'
-MULTUS_IMAGE=quay.io/kubevirt/cluster-network-addon-multus@sha256:b7487e14aa0e4f4d0b8f6a626af7d420b4cd0d8bda2fda1eb652c310526db1f8
-cp cluster/multus-daemonset.do-not-change.yml cluster/multus-daemonset.yml
-sed -i "s#ghcr.io/k8snetworkplumbingwg/multus-cni:stable\$#$MULTUS_IMAGE#" cluster/multus-daemonset.yml
 ./cluster/kubectl.sh create -f cluster/multus-daemonset.yml
 ./cluster/kubectl.sh -n kube-system wait --for=condition=ready -l name=multus pod --timeout=300s


### PR DESCRIPTION
We currently use an ancient version of Multus.

With this patch, we will follow the latest stable release. As of today
that is 3.9.

Assuming Multus keeps their released images stable, this patch removes
the cached image in favor of the official channel.

Note that this also switches from thin Multus CNI to the thick version
of the plugin.

Signed-off-by: Petr Horáček <phoracek@redhat.com>

Signed-off-by: Petr Horáček <phoracek@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
